### PR TITLE
Add a dropdown item for going to the options page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,17 @@
 # Sideloading the extension to different browsers
 
-After building the extension, sideload the extension located in the `dist` folder.
+After building the extension, sideload the extension located under the `dist` folder.
 
-## Chromium based browsers (Google Chrome, Microsoft Edge, Brave, etc.)
+## Chromium-based browsers (Google Chrome, Microsoft Edge, Brave, etc.)
 1. Open the extensions page by visiting `chrome://extensions`, `edge://extensions`, `brave://extensions`, etc.
 2. Enable `Developer mode`.
-3. Click `Load unpacked` and provide the location to the `dist` folder.
-4. Upon loading the extension, the `Unrecognized manifest key 'browser_specfic_settings` warning can be ignored.
-5. In the extension's `Permissions` tab, provide the permissions to access data for `https://github.com`.
+3. Click `Load unpacked` and provide the location to the `dist/chromium` folder.
+4. In the extension's `Permissions` tab, provide the permissions to access data for `https://github.com`.
 
 ## Firefox version
 1. Open the `about:debugging` page.
 2. Navigate to `This Firefox`.
-3. Click `Load Temporary Add-on` then select any file in the `dist` folder.
+3. Click `Load Temporary Add-on` then select any file in the `dist/firefox-safari` folder.
 4. Open the `about:addons` page.
 5. Under the extensions `Permissions` tab, provide permissions for the extension to access data on `https://github.com`.
 
@@ -23,7 +22,7 @@ To sideload the extension on Safari, Xcode is required.
 
 1. Open the terminal and run the following to create and open an Xcode project for the web extension:
 ```
-xcrun safari-web-extension-converter /path/to/dist/folder
+xcrun safari-web-extension-converter /path/to/dist/firefox-safari
 ```
 2. In the Xcode project, set the build target to `Try in Dev Spaces (macOS)` and start the build by pressing ▶.
 

--- a/README.md
+++ b/README.md
@@ -14,16 +14,35 @@ Additional Dev Spaces (and upstream Eclipse Che®) instances can configured from
 
  - Access to your data on github.com. This is required to determine the factory url for the button, and for injecting the button element into the webpage.
 
-## Quick start
+## Building and running locally
 
-1. Download dependencies and build the extension. The built extension will be located in the generated `dist` folder.
+The extension can be built for both Chromium based browsers and for Firefox/Safari.
+There are two builds because the two platforms have different manifest V3 definitions.
+
+1. Download dependencies.
 ```
-$ yarn && yarn build
+$ yarn
+```
+
+2. Run the build.
+
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+To build for Chromium-based browsers:
+```
+$ yarn build
 ```
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-For development, run `yarn watch` to watch the source files to recompile on changes.
+To build for Firefox or Safari:
+```
+$ yarn build:firefox-safari
+```
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+Once complete, the built extension will be located in either `dist/chromium` or `dist/firefox-safari`.
 
-2. Sideload the extension located in the `dist` folder into your web browser.
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+For development, run `yarn watch` or `yarn watch:firefox-safari` to watch the source files to recompile on changes.
+
+3. Sideload the extension located under the `dist` folder into your web browser.
 For instructions for different web browsers, refer to [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## Running tests

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,5 +10,6 @@ module.exports = {
     moduleNameMapper : {
         '\\.(css)$': '<rootDir>/src/contentScript/buttonInjector/__mocks__/css.ts'
     },
-    testEnvironment: "jsdom"
+    testEnvironment: "jsdom",
+    setupFilesAfterEnv: ['./jest.setup.js'],
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+Object.assign(global, require('jest-chrome'))

--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,9 @@
       "id": "{e5b67b9e-a1bd-11ed-a8fc-0242ac120002}"
     }
   },
+  "background": {
+    "service_worker": "backgroundScript.bundle.js"
+  }, 
   "content_scripts": [
     {
       "js": [

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@webpack-cli/generators": "^3.0.1",
     "clean-webpack-plugin": "^4.0.0",
     "copy-webpack-plugin": "^11.0.0",
+    "cross-env": "^7.0.3",
     "css-loader": "^6.7.3",
     "html-webpack-plugin": "^5.5.0",
     "jest": "^29.4.2",
@@ -29,8 +30,10 @@
   },
   "scripts": {
     "build": "webpack --mode=development",
-    "build:prod": "webpack --mode=production --node-env=production",
+    "build:firefox-safari": "cross-env TARGET=firefox-safari webpack --mode=development",
+    "build:prod": "cross-env NODE_ENV=production webpack --mode=production",
     "watch": "yarn build --watch",
+    "watch:firefox-safari": "yarn build:firefox-safari --watch",
     "test": "jest"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "css-loader": "^6.7.3",
     "html-webpack-plugin": "^5.5.0",
     "jest": "^29.4.2",
+    "jest-chrome": "^0.8.0",
     "jest-environment-jsdom": "^29.4.2",
     "mini-css-extract-plugin": "^2.7.2",
     "prettier": "^2.8.3",

--- a/src/backgroundScript/backgroundScript.ts
+++ b/src/backgroundScript/backgroundScript.ts
@@ -1,0 +1,16 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+export const OPEN_OPTIONS = "openOptionsPage";
+
+chrome.runtime.onMessage.addListener((message) => {
+    switch (message.action) {
+        case OPEN_OPTIONS:
+            chrome.runtime.openOptionsPage();
+            break;
+        default:
+            break;
+    }
+});

--- a/src/contentScript/buttonInjector/github/GitHubButtonInjector.ts
+++ b/src/contentScript/buttonInjector/github/GitHubButtonInjector.ts
@@ -8,6 +8,7 @@ import { ButtonInjector } from "../ButtonInjector";
 import { getFactoryUrl, getHostName, getProjectURL } from "../util";
 import { createPopper } from "@popperjs/core";
 import "./github.css";
+import { OPEN_OPTIONS } from '../../../backgroundScript/backgroundScript';
 
 export class GitHubButtonInjector implements ButtonInjector {
     private static BUTTON_ID = "try-in-web-ide-btn";
@@ -41,34 +42,7 @@ export class GitHubButtonInjector implements ButtonInjector {
         const actionBar = document.querySelector(".file-navigation");
         const project = getProjectURL();
         const endpoints = await getEndpoints();
-        if (endpoints.length === 1) {
-            this.injectButtonNoDropdown(actionBar, project, endpoints[0]);
-        } else {
-            this.injectButtonDropdown(actionBar, project, endpoints);
-        }
-    }
-
-    /**
-     * @param element the DOM element to inject the button into
-     * @param projectUrl the project url
-     * @param endpoints the configured Dev Spaces endpoint
-     */
-    private injectButtonNoDropdown(
-        element: Element,
-        projectUrl: string,
-        endpoint: Endpoint
-    ) {
-        const btnGroup = document.createElement("div");
-        btnGroup.id = GitHubButtonInjector.BUTTON_ID;
-        btnGroup.className = "gh-btn-group ml-2";
-        const btn = document.createElement("a");
-        btn.href = endpoint.url + "/#" + projectUrl;
-        btn.target = "_blank";
-        btn.title = "Open the project on " + endpoint.url;
-        btn.className = "gh-btn btn-primary";
-        btn.appendChild(document.createTextNode("Dev Spaces"));
-        btnGroup.appendChild(btn);
-        element.appendChild(btnGroup);
+        this.injectButtonDropdown(actionBar, project, endpoints);
     }
 
     /**
@@ -109,6 +83,11 @@ export class GitHubButtonInjector implements ButtonInjector {
                 this.createEndpiontListItem(projectUrl, e)
             );
         });
+        dropdownContent.appendChild(
+            this.createDivider()
+        );
+
+        dropdownContent.appendChild(this.createConfigureItem());
 
         btnGroup.appendChild(dropdownContent);
         element.appendChild(btnGroup);
@@ -145,6 +124,27 @@ export class GitHubButtonInjector implements ButtonInjector {
         }
 
         li.append(a);
+        return li;
+    }
+
+    private createDivider() {
+        const li = document.createElement("li");
+        const hr = document.createElement("hr");
+        hr.className = "gh-dropdown-divider";
+        li.appendChild(hr);
+        return li;
+    }
+
+    private createConfigureItem() {
+        const li = document.createElement("li");
+        li.className = "gh-list-item";
+        const a = document.createElement("a");
+        a.className = "gh-dropdown-item";
+        a.appendChild(document.createTextNode("Configure"));
+        a.onclick = () => {
+            chrome.runtime.sendMessage({action: OPEN_OPTIONS});
+        }
+        li.appendChild(a);
         return li;
     }
 

--- a/src/contentScript/buttonInjector/github/github.css
+++ b/src/contentScript/buttonInjector/github/github.css
@@ -162,3 +162,11 @@
     -webkit-user-select: none;
     user-select: none;
 }
+
+.gh-dropdown-divider {
+    height: 0;
+    margin: 0.2rem 0;
+    overflow: hidden;
+    border-bottom: 1px solid var(--color-border-muted, hsla(210,18%,87%,1));
+    opacity: 1;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,12 @@ const config = {
       'contentScript',
       'contentScript.ts'
     ),
+    backgroundScript: path.join(
+      __dirname,
+      'src',
+      'backgroundScript',
+      'backgroundScript.ts'
+    ),
   },
   output: {
     filename: '[name].bundle.js',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1971,7 +1971,14 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
-cross-spawn@^7.0.3:
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
+cross-spawn@^7.0.1, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -904,6 +904,14 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/chrome@^0.0.114":
+  version "0.0.114"
+  resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.114.tgz#8ceb33fa261f4b9e307fa7344ba8182d8d410d4e"
+  integrity sha512-i7qRr74IrxHtbnrZSKUuP5Uvd5EOKwlwJq/yp7+yTPihOXnPhNQO4Z5bqb1XTnrjdbUKEJicaVVbhcgtRijmLA==
+  dependencies:
+    "@types/filesystem" "*"
+    "@types/har-format" "*"
+
 "@types/chrome@^0.0.211":
   version "0.0.211"
   resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.211.tgz#2e52cd17a2a3f2d807e1fc1457c271f6120c6730"
@@ -3100,6 +3108,13 @@ jest-changed-files@^29.4.2:
   dependencies:
     execa "^5.0.0"
     p-limit "^3.1.0"
+
+jest-chrome@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/jest-chrome/-/jest-chrome-0.8.0.tgz#f741f5cf49292326eb9a2507111b9a77a01a495d"
+  integrity sha512-39RR1GT9nI4e4jsuH1vIf4l5ApxxkcstjGJr+GsOURL8f4Db0UlbRnsZaM+ZRniaGtokqklUH5VFKGZZ6YztUg==
+  dependencies:
+    "@types/chrome" "^0.0.114"
 
 jest-circus@^29.4.2:
   version "29.4.2"


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/try-in-dev-spaces-browser-extension/issues/22

This PR adds a dropdown item that brings the user to the options page:
<img width="366" alt="image" src="https://user-images.githubusercontent.com/83611742/219816696-0ab03234-b132-4878-a203-c402733f7d00.png">

<details><summary>Demo video: </summary>

https://user-images.githubusercontent.com/83611742/219819240-0669fbdf-ff49-4e6a-b275-0a4c44e5bb27.mov

</details>


This PR also adds new scripts in `package.json`:
```
    "build:firefox-safari": "cross-env TARGET=firefox-safari webpack --mode=development",
    "watch:firefox-safari": "yarn build:firefox-safari --watch",
```
used to build/watch the extension for use with Firefox/Safari.

This is because there are small differences in how things are defined in the V3 manifest. For our case:
1. The background script is declared differently
2. The `browser_specific_settings` field causes a warning on Chromium based browsers. (This field is necessary for Firefox to use [storage.sync](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/sync) api)


To test this PR:

On Google chrome,
1. Run `yarn && yarn build` and sideload the extension
2. Click on the 'Configure' dropdown item in the dropdown
3. The options page should open

To test the new commands in this PR:

1. Run `yarn build` and confirm that the extension is built in `dist/chromium`
2. Run `yarn build:firefox-safari` and confirm that the extension is built in `dist/firefox-safari`
3. Sideload each extension on Google Chrome / Firefox / Safari
