### PR TITLE
Inject button only if 'Code' button exists

### DIFF
--- a/src/contentScript/buttonInjector/github/Button.tsx
+++ b/src/contentScript/buttonInjector/github/Button.tsx
@@ -100,7 +100,7 @@ export const Button = (props: Props) => {
                 className="gh-btn btn-primary"
                 href={getFactoryURL(props.projectURL, defaultEndpoint)}
                 target="_blank"
-                title="Open the project on https://url-1.com"
+                title={"Open the project on " + defaultEndpoint.url}
             >
                 Dev Spaces
             </a>

--- a/src/contentScript/buttonInjector/github/GitHubButtonInjector.tsx
+++ b/src/contentScript/buttonInjector/github/GitHubButtonInjector.tsx
@@ -24,7 +24,22 @@ export class GitHubButtonInjector implements ButtonInjector {
         const actionBar = document.querySelector(
             GitHubButtonInjector.GITHUB_ELEMENT
         );
-        return !!actionBar;
+        
+        if (!actionBar) {
+            return false;
+        }
+
+        return this.codeBtnExists(actionBar);
+    }
+
+    private static codeBtnExists(element: Element): boolean {
+        const btnList = element.getElementsByClassName("btn-primary btn");
+        for (const btn of btnList) {
+            if ((btn as HTMLElement).innerText.indexOf("Code") > -1) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public async inject() {

--- a/src/contentScript/buttonInjector/github/__tests__/GitHubButtonInjector.spec.ts
+++ b/src/contentScript/buttonInjector/github/__tests__/GitHubButtonInjector.spec.ts
@@ -18,6 +18,60 @@ jest.mock("../../util", () => ({
     }),
 }));
 
+describe("Test GitHubButtonInjector.matches()", () => {
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should return true if div has 'Code' button", async () => {
+        preferencesMock.setEndpoints([
+            { url: "https://url-1.com", active: true, readonly: true },
+        ]);
+
+        jest.spyOn(document, "querySelector").mockImplementation(
+            (_: string) => {
+                const div = document.createElement("div");
+                div.className = "file-navigation";
+                const codeBtn = document.createElement("summary");
+                codeBtn.className = "btn-primary btn";
+                codeBtn.innerText = "Code";
+                div.appendChild(codeBtn);
+                return div;
+            }
+        );
+        expect(GitHubButtonInjector.matches()).toBe(true);
+    });
+
+    it("should return false if div does not have 'Code' button", async () => {
+        preferencesMock.setEndpoints([
+            { url: "https://url-1.com", active: true, readonly: true },
+        ]);
+
+        jest.spyOn(document, "querySelector").mockImplementation(
+            (_: string) => {
+                const div = document.createElement("div");
+                div.className = "file-navigation";
+                return div;
+            }
+        );
+        expect(GitHubButtonInjector.matches()).toBe(false);
+    });
+
+    it("should return false if div not found", async () => {
+        preferencesMock.setEndpoints([
+            { url: "https://url-1.com", active: true, readonly: true },
+        ]);
+
+        jest.spyOn(document, "querySelector").mockImplementation(
+            (_: string) => {
+                return null;
+            }
+        );
+        expect(GitHubButtonInjector.matches()).toBe(false);
+    });
+});
+
 describe("Inject button on GitHub project repo page", () => {
     let githubService: GitHubButtonInjector;
 
@@ -72,6 +126,10 @@ describe("Inject button on GitHub project repo page", () => {
             (_: string) => {
                 const div = document.createElement("div");
                 div.className = "file-navigation";
+                const codeBtn = document.createElement("summary");
+                codeBtn.className = "btn-primary btn";
+                codeBtn.innerText = "Code";
+                div.appendChild(codeBtn);
                 return div;
             }
         );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "outDir": "./dist",
     "rootDir": ".",
     "noEmit": false,
-    "target": "es5",
+    "target": "es2015",
     "esModuleInterop": true,
   },
   "include": [


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/try-in-dev-spaces-browser-extension/issues/31

https://user-images.githubusercontent.com/83611742/222575428-462b46a4-6525-40cd-b80e-17ec263a7f94.mov


To test this PR:
1. checkout this PR, run `yarn build`
2. Sideload the extension located in `dist/chromium`
3. Follow the steps in the demo video above
4. Run `yarn test`