### PR TITLE
Prevent storing default endpoint (workspace.openshift.com) in sync.storage

### DIFF
--- a/src/contentScript/buttonInjector/github/Button.tsx
+++ b/src/contentScript/buttonInjector/github/Button.tsx
@@ -7,7 +7,7 @@ import React from "react";
 import { usePopper } from "react-popper";
 import { OPEN_OPTIONS } from "../../../backgroundScript/backgroundScript";
 
-import { Endpoint, getDefaultEndpoint } from "../../../preferences/preferences";
+import { Endpoint, getActiveEndpoint } from "../../../preferences/preferences";
 import { getFactoryURL } from "../util";
 import { DropdownItem } from "./DropdownItem";
 import { DropdownMenu, DropdownMenuDivider } from "./DropdownMenu";
@@ -92,7 +92,7 @@ export const Button = (props: Props) => {
         </DropdownMenu>
     );
 
-    const defaultEndpoint = getDefaultEndpoint(props.endpoints);
+    const defaultEndpoint = getActiveEndpoint(props.endpoints);
 
     return (
         <div className="gh-btn-group ml-2" id="try-in-web-ide-btn">

--- a/src/contentScript/buttonInjector/github/GitHubButtonInjector.tsx
+++ b/src/contentScript/buttonInjector/github/GitHubButtonInjector.tsx
@@ -6,7 +6,7 @@
 import ReactDOM from "react-dom/client";
 import {
     Endpoint,
-    getDefaultEndpoint,
+    getActiveEndpoint,
     getEndpoints,
 } from "../../../preferences/preferences";
 import { ButtonInjector } from "../ButtonInjector";
@@ -96,7 +96,7 @@ export class GitHubButtonInjector implements ButtonInjector {
     }
 
     private setActiveEndpointToFront(endpoints: Endpoint[]) {
-        const active = getDefaultEndpoint(endpoints);
+        const active = getActiveEndpoint(endpoints);
         endpoints.splice(
             endpoints.findIndex((e) => e.active),
             1

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -38,12 +38,13 @@ export const App = () => {
     const [newEndpointStatus, setNewEndpointStatus] = useState<validate>("default");
 
     useEffect(() => {
-        const fetchData = async () => {
-            const endpoints = await getEndpoints();
-            setEndpoints(endpoints);
-        };
-        fetchData().catch(console.error);
+        updateEndpoints().catch(console.error);
     }, []);
+
+    const updateEndpoints = async () => {
+        const endpoints = await getEndpoints();
+        setEndpoints(endpoints);
+    }
 
     const handleNewEndpointUrlChange = (newUrl: string, _event: React.FormEvent<HTMLInputElement>) => {
         setNewEndpointUrl(newUrl);
@@ -73,7 +74,7 @@ export const App = () => {
             readonly: false,
         });
         await saveEndpoints(newEndpoints);
-        await setEndpoints(newEndpoints);
+        await updateEndpoints();
         setNewEndpointUrl("");
         setNewEndpointStatus("default");
     };
@@ -92,13 +93,14 @@ export const App = () => {
             e.active = e == endpoint;
         });
         await saveEndpoints(newEndpoints);
-        await setEndpoints(newEndpoints);
+        await updateEndpoints();
+
     };
 
     const deleteEndpoint = async (endpoint: Endpoint) => {
         const newEndpoints = endpoints.filter((e) => e != endpoint);
         await saveEndpoints(newEndpoints);
-        await setEndpoints(newEndpoints);
+        await updateEndpoints();
     };
 
     const list = endpoints.length && (

--- a/src/preferences/__tests__/preferences.spec.ts
+++ b/src/preferences/__tests__/preferences.spec.ts
@@ -1,0 +1,124 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import { chrome } from "jest-chrome";
+import { Endpoint, getEndpoints, saveEndpoints } from "../preferences";
+
+const defaultEndpoint: Endpoint = {
+    url: "https://workspaces.openshift.com",
+    active: true,
+    readonly: true,
+};
+
+afterEach(() => {
+    jest.clearAllMocks();
+});
+
+describe("Test getEndpoints()", () => {
+    it("should contain default endpoint, no stored endpoints", async () => {
+        chrome.storage.sync.get.mockImplementation(() => {
+            return { endpoints: [] };
+        });
+        const endpoints: Endpoint[] = await getEndpoints();
+
+        expect(endpoints).toEqual([defaultEndpoint]);
+    });
+
+    it("should contain default endpoint at the front with a stored inactive endpoint", async () => {
+        const storedEndpoints: Endpoint[] = [
+            { url: "https://url-1.com", active: false, readonly: false },
+        ];
+        chrome.storage.sync.get.mockImplementation(() => {
+            return { endpoints: storedEndpoints };
+        });
+        const endpoints: Endpoint[] = await getEndpoints();
+
+        expect(endpoints).toEqual([defaultEndpoint, ...storedEndpoints]);
+    });
+
+    it("should contain default endpoint at the front with a stored active endpoint", async () => {
+        const storedEndpoints: Endpoint[] = [
+            { url: "https://url-1.com", active: true, readonly: false },
+        ];
+        chrome.storage.sync.get.mockImplementation(() => {
+            return { endpoints: storedEndpoints };
+        });
+        const endpoints: Endpoint[] = await getEndpoints();
+
+        expect(endpoints).toEqual([
+            { ...defaultEndpoint, active: false },
+            ...storedEndpoints,
+        ]);
+    });
+
+    it("should contain default endpoint at the front with many endpoints", async () => {
+        const storedEndpoints: Endpoint[] = [
+            { url: "https://url-1.com", active: false, readonly: false },
+            { url: "https://url-2.com", active: false, readonly: false },
+            { url: "https://url-3.com", active: true, readonly: false },
+            { url: "https://url-4.com", active: false, readonly: false },
+        ];
+        chrome.storage.sync.get.mockImplementation(() => {
+            return { endpoints: storedEndpoints };
+        });
+        const endpoints: Endpoint[] = await getEndpoints();
+
+        expect(endpoints).toEqual([
+            {
+                url: "https://workspaces.openshift.com",
+                active: false,
+                readonly: true,
+            },
+            ...storedEndpoints,
+        ]);
+    });
+});
+
+describe("Test saveEndpoints()", () => {
+    let savedEndpoints;
+    beforeEach(() => {
+        chrome.storage.sync.set.mockImplementation((data) => {
+            savedEndpoints = data.endpoints;
+        });
+    });
+
+    it("should not save the default endpoint", async () => {
+        const inputEndpoints: Endpoint[] = [defaultEndpoint];
+        await saveEndpoints(inputEndpoints);
+        expect(savedEndpoints).toEqual([]);
+    });
+
+    it("should save the non-default endpoint", async () => {
+        const inputEndpoints: Endpoint[] = [
+            defaultEndpoint,
+            { url: "https://url-1.com", active: false, readonly: false },
+        ];
+        await saveEndpoints(inputEndpoints);
+        expect(savedEndpoints).toEqual([
+            {
+                url: "https://url-1.com",
+                active: false,
+                readonly: false,
+            },
+        ]);
+    });
+
+    it("should save the non-default endpoints", async () => {
+        const inputEndpoints: Endpoint[] = [
+            defaultEndpoint,
+            { url: "https://url-1.com", active: false, readonly: false },
+            { url: "https://url-2.com", active: false, readonly: false },
+            { url: "https://url-3.com", active: false, readonly: false },
+            { url: "https://url-4.com", active: false, readonly: false },
+        ];
+        await saveEndpoints(inputEndpoints);
+        expect(savedEndpoints).toEqual([
+            { url: "https://url-1.com", active: false, readonly: false },
+            { url: "https://url-2.com", active: false, readonly: false },
+            { url: "https://url-3.com", active: false, readonly: false },
+            { url: "https://url-4.com", active: false, readonly: false },
+        ]);
+    });
+});


### PR DESCRIPTION
Fixes #https://github.com/redhat-developer/try-in-dev-spaces-browser-extension/issues/33

Draft PR since this PR depends on https://github.com/redhat-developer/try-in-dev-spaces-browser-extension/pull/30

There aren't any user-noticable changes introduced in this PR.

To test that this PR does not break storing new endpoints,
1. `yarn build`, sideload the extension located in `dist/chromium` in Google Chrome
2. Open the options page, and add a new endpoint
3. Close the options page
4. Open the options page again and verify that the new endpoint and the default endpoint (workspaces.openshift.com) still exists
5. Go to a GitHub repo page and verify that the button is injected with a dropdown containing the endpoints in the options page.
6. Go to the options page, remove endpoint, reopen options page to verify changes persisted
