### PR TITLE
Clear existing event listener for GH btn if exists

### DIFF
--- a/src/contentScript/buttonInjector/github/GitHubButtonInjector.tsx
+++ b/src/contentScript/buttonInjector/github/GitHubButtonInjector.tsx
@@ -17,6 +17,8 @@ export class GitHubButtonInjector implements ButtonInjector {
     private static BUTTON_ID = "try-in-web-ide-btn";
     private static GITHUB_ELEMENT = ".file-navigation";
 
+    private root: ReactDOM.Root | undefined;
+
     /**
      * @returns true if current page is a GitHub page to inject the button to
      */
@@ -51,6 +53,9 @@ export class GitHubButtonInjector implements ButtonInjector {
         document.addEventListener("turbo:load", () => {
             if (GitHubButtonInjector.matches()) {
                 this._inject();
+            } else if (this.root) {
+                this.root.unmount();
+                this.root = undefined;
             }
         });
     }
@@ -64,9 +69,8 @@ export class GitHubButtonInjector implements ButtonInjector {
 
         const rootElement = document.createElement("div");
         rootElement.id = GitHubButtonInjector.BUTTON_ID;
-        const root = ReactDOM.createRoot(rootElement);
-
-        root.render(<Button endpoints={endpoints} projectURL={projectURL} />);
+        this.root = ReactDOM.createRoot(rootElement);
+        this.root.render(<Button endpoints={endpoints} projectURL={projectURL} />);
         ghElement.appendChild(rootElement);
     }
 

--- a/src/contentScript/buttonInjector/github/__tests__/Button.spec.tsx
+++ b/src/contentScript/buttonInjector/github/__tests__/Button.spec.tsx
@@ -4,7 +4,7 @@
  *-----------------------------------------------------------------------------------------------*/
 
 import { act } from "react-dom/test-utils";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, RenderResult, screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
 import { Button } from "../Button";
@@ -54,6 +54,11 @@ describe("Snapshot tests", () => {
 });
 
 describe("Functional tests", () => {
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
     it("should have correct href for main button", async () => {
         let endpoints = [
             { url: "https://url-1.com", active: true, readonly: true },
@@ -160,6 +165,32 @@ describe("Functional tests", () => {
         expect(chrome.runtime.sendMessage).toBeCalledWith({
             action: "openOptionsPage",
         });
+    });
+
+    it("should remove click event listener on component unmount", async () => {
+        const endpoints = [
+            { url: "https://url-1.com", active: true, readonly: true },
+        ];
+
+        const addListenerSpy = jest.spyOn(window, "addEventListener");
+        const removeListenerSpy = jest.spyOn(window, "removeEventListener");
+
+        let renderResult: RenderResult;
+        act(() => {
+            renderResult = render(
+                <Button endpoints={endpoints} projectURL={projectURL} />
+            );
+        });
+
+        expect(addListenerSpy).toBeCalledWith(
+            "click",
+            expect.any(Function)
+        );
+        renderResult.unmount();
+        expect(removeListenerSpy).toBeCalledWith(
+            "click",
+            expect.any(Function)
+        );
     });
 });
 


### PR DESCRIPTION
When the `turbo:load` event fires when clicking the 'Issues' tab in a GH project page, the injected button component is not being unmounted and therefore the `click` event listener is not being cleared.

This PR unmounts the react injected GH button component if the `turbo:load` event fires and the resulting webpage should not have the button be injected.

To test this PR:
1. Check out the PR branch and run:
```
curl https://gist.githubusercontent.com/dkwon17/b117f051a0a89560fec6dfa6aecf1d67/raw/f6eabf227a83fd74ae245b2ee2de14de0c48bb37/patchfile | git apply -v
```
The patch adds `console.log` statements to help verify that the event listener is being removed.
2. Run `yarn build` and sideload the built extension in `dist/chromium` to Google Chrome
3. Go to a GH project page (ex. https://github.com/redhat-developer/try-in-dev-spaces-browser-extension/)
4. Follow the steps in this video to verify that the button component is being unmounted when viewing the 'Issues' tab:

https://user-images.githubusercontent.com/83611742/223220734-28a74f53-f146-4a9a-ad08-dff0c72317f4.mov

To summarize:
a. When clicking on the webpage while the button exists, `click!` should be printed in the console only once per click
b. When clicking on the 'Issues' tab, the `turbo:load` event fires, and the component should be unmounted. As a result `unmounted!` should be printed in the console.
c. Going back to the 'Code' tab, the button should be injected again, and `click!` should be printed in the console only once per click. This confirms that the previous `click ` event listener has been removed. Before this PR `click!` would have been printed twice per click in this case.

5. Run `yarn test` to ensure all tests pass


 