### PR TITLE
Open workspace in new tab when using dropdown menu

### DIFF
--- a/src/contentScript/buttonInjector/github/DropdownItem.tsx
+++ b/src/contentScript/buttonInjector/github/DropdownItem.tsx
@@ -8,6 +8,7 @@ import { PropsWithChildren } from "react";
 interface Props {
     href?: string;
     onClick?: React.MouseEventHandler;
+    newTab?: boolean;
 }
 
 export const DropdownItem = (props: PropsWithChildren<Props>) => {
@@ -27,6 +28,9 @@ const getAttributes = (props: Props): any => {
     }
     if (props.onClick) {
         attr.onClick = props.onClick;
+    }
+    if (props.newTab) {
+        attr.target = "_blank"
     }
     return attr;
 };

--- a/src/contentScript/buttonInjector/github/EndpointDropdownItem.tsx
+++ b/src/contentScript/buttonInjector/github/EndpointDropdownItem.tsx
@@ -17,7 +17,7 @@ export const EndpointDropdownItem = (props: Props) => {
     const text = `Open with ${getHostName(props.endpoint)}`;
 
     return (
-        <DropdownItem href={href}>
+        <DropdownItem href={href} newTab>
             {text}
             {props.endpoint.active && (
                 <div className="gh-pill-badge">Default</div>

--- a/src/contentScript/buttonInjector/github/__tests__/__snapshots__/Button.spec.tsx.snap
+++ b/src/contentScript/buttonInjector/github/__tests__/__snapshots__/Button.spec.tsx.snap
@@ -56,6 +56,7 @@ exports[`Snapshot tests renders correctly with multiple endpoints, with dropdown
         <a
           class="gh-dropdown-item"
           href="https://url-1.com/#https://github.com/redhat-developer/try-in-dev-spaces-browser-extension"
+          target="_blank"
         >
           Open with url-1.com
           <div
@@ -71,6 +72,7 @@ exports[`Snapshot tests renders correctly with multiple endpoints, with dropdown
         <a
           class="gh-dropdown-item"
           href="https://url-2.com/#https://github.com/redhat-developer/try-in-dev-spaces-browser-extension"
+          target="_blank"
         >
           Open with url-2.com
         </a>
@@ -81,6 +83,7 @@ exports[`Snapshot tests renders correctly with multiple endpoints, with dropdown
         <a
           class="gh-dropdown-item"
           href="https://url-3.com/#https://github.com/redhat-developer/try-in-dev-spaces-browser-extension"
+          target="_blank"
         >
           Open with url-3.com
         </a>


### PR DESCRIPTION
Currently when opening a new workspace using the dropdown, the factory url is being opened in the current tab, and not on a new tab.

When using the dropdown, this PR opens the factory url in a new tab.

Demo:

https://user-images.githubusercontent.com/83611742/223281146-ca0fff29-3848-4a06-8467-d69bc8c39d93.mov

