### PR TITLE
Update malformed URL error msg for options page

### DIFF
--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -21,7 +21,8 @@ import {
     TextInput,
     CardTitle,
 } from "@patternfly/react-core";
-import { ExclamationCircleIcon } from "@patternfly/react-icons";
+import { ExclamationCircleIcon } from "@patternfly/react-icons/dist/js/icons/exclamation-circle-icon";
+
 import {
     Endpoint,
     getEndpoints,
@@ -33,9 +34,10 @@ import "./styles/App.css";
 export const App = () => {
     const [endpoints, setEndpoints] = useState<Endpoint[]>([]);
     const [newEndpointUrl, setNewEndpointUrl] = useState<string>("");
-    
+
     type validate = "success" | "error" | "default";
-    const [newEndpointStatus, setNewEndpointStatus] = useState<validate>("default");
+    const [newEndpointStatus, setNewEndpointStatus] =
+        useState<validate>("default");
 
     useEffect(() => {
         updateEndpoints().catch(console.error);
@@ -44,16 +46,19 @@ export const App = () => {
     const updateEndpoints = async () => {
         const endpoints = await getEndpoints();
         setEndpoints(endpoints);
-    }
+    };
 
-    const handleNewEndpointUrlChange = (newUrl: string, _event: React.FormEvent<HTMLInputElement>) => {
+    const handleNewEndpointUrlChange = (
+        newUrl: string,
+        _event: React.FormEvent<HTMLInputElement>
+    ) => {
         setNewEndpointUrl(newUrl);
         if (newUrl === "") {
-          setNewEndpointStatus("default");
+            setNewEndpointStatus("default");
         } else if (isUrl(newUrl)) {
-          setNewEndpointStatus("success");
+            setNewEndpointStatus("success");
         } else {
-          setNewEndpointStatus("error");
+            setNewEndpointStatus("error");
         }
     };
 
@@ -64,7 +69,7 @@ export const App = () => {
             return false;
         }
         return true;
-    }
+    };
 
     const addNewEndpoint = async () => {
         const sanitizedEndpoint = sanitizeEndpoint(newEndpointUrl);
@@ -85,7 +90,7 @@ export const App = () => {
             res = res.substring(0, res.length - 1);
         }
         return res;
-    }
+    };
 
     const setDefault = async (endpoint: Endpoint) => {
         const newEndpoints = [...endpoints];
@@ -94,7 +99,6 @@ export const App = () => {
         });
         await saveEndpoints(newEndpoints);
         await updateEndpoints();
-
     };
 
     const deleteEndpoint = async (endpoint: Endpoint) => {
@@ -111,6 +115,23 @@ export const App = () => {
         />
     );
 
+    const helperTextInvalid = (
+        <Split className="pf-u-mt-xs">
+            <SplitItem>
+                <ExclamationCircleIcon
+                    color="var(--pf-global--danger-color--100)"
+                    className="pf-u-mr-xs"
+                />
+            </SplitItem>
+            <SplitItem>
+                <div className="pf-c-form__helper-text pf-m-error">
+                    Provide the URL of your Dev Spaces installation, e.g.,
+                    https://devspaces.mycluster.redhat.com
+                </div>
+            </SplitItem>
+        </Split>
+    );
+
     return (
         <Card>
             <CardTitle>Dev Spaces endpoints</CardTitle>
@@ -122,8 +143,11 @@ export const App = () => {
                         <Form>
                             <FormGroup
                                 validated={newEndpointStatus}
-                                helperTextInvalid="The new endpoint must be a URL"
-                                helperTextInvalidIcon={<ExclamationCircleIcon />}>
+                                helperTextInvalid={helperTextInvalid}
+                                helperTextInvalidIcon={
+                                    <ExclamationCircleIcon />
+                                }
+                            >
                                 <TextInput
                                     type="text"
                                     aria-label="new endpoint"
@@ -137,7 +161,14 @@ export const App = () => {
                     </SplitItem>
                     <SplitItem className="form-fill" isFilled></SplitItem>
                     <SplitItem>
-                        <Button variant="primary" onClick={addNewEndpoint} isDisabled={newEndpointUrl.length === 0 || newEndpointStatus === "error"}>
+                        <Button
+                            variant="primary"
+                            onClick={addNewEndpoint}
+                            isDisabled={
+                                newEndpointUrl.length === 0 ||
+                                newEndpointStatus === "error"
+                            }
+                        >
                             Add
                         </Button>
                     </SplitItem>

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -126,7 +126,7 @@ export const App = () => {
             <SplitItem>
                 <div className="pf-c-form__helper-text pf-m-error">
                     Provide the URL of your Dev Spaces installation, e.g.,
-                    https://devspaces.mycluster.redhat.com
+                    https://devspaces.mycluster.mycorp.com
                 </div>
             </SplitItem>
         </Split>

--- a/src/options/__tests__/App.spec.tsx
+++ b/src/options/__tests__/App.spec.tsx
@@ -117,3 +117,14 @@ it("should disable 'Add' button when invalid input is entered in the input box",
     fireEvent.change(inputBox, {target: {value: "123412341234"}})
     expect(addButton.classList.contains("pf-m-disabled")).toBe(true);
 });
+
+it("should display error message when invalid input is entered in the input box", async () => {
+    preferencesMock.setEndpoints([
+        { url: "https://url-1.com", active: true, readonly: true },
+    ]);
+
+    const { findByPlaceholderText, findByText } = render(<App />);
+    const inputBox = await findByPlaceholderText("Add endpoint");
+    fireEvent.change(inputBox, {target: {value: "invalidtext"}})
+    await findByText("Provide the URL of your Dev Spaces installation, e.g., https://devspaces.mycluster.redhat.com");
+});

--- a/src/options/__tests__/App.spec.tsx
+++ b/src/options/__tests__/App.spec.tsx
@@ -126,5 +126,5 @@ it("should display error message when invalid input is entered in the input box"
     const { findByPlaceholderText, findByText } = render(<App />);
     const inputBox = await findByPlaceholderText("Add endpoint");
     fireEvent.change(inputBox, {target: {value: "invalidtext"}})
-    await findByText("Provide the URL of your Dev Spaces installation, e.g., https://devspaces.mycluster.redhat.com");
+    await findByText("Provide the URL of your Dev Spaces installation, e.g., https://devspaces.mycluster.mycorp.com");
 });

--- a/src/options/__tests__/DropdownMenu.spec.tsx
+++ b/src/options/__tests__/DropdownMenu.spec.tsx
@@ -4,7 +4,7 @@
  *-----------------------------------------------------------------------------------------------*/
 
 import { act } from "react-dom/test-utils";
-import { Matcher, MatcherOptions, render, waitFor } from "@testing-library/react";
+import { Matcher, MatcherOptions, render } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
 import { DropdownMenu } from "../DropdownMenu";


### PR DESCRIPTION
Fixes #39 

The new error message:
<img width="709" alt="image" src="https://user-images.githubusercontent.com/83611742/223836172-6fa62750-6b3a-4b6b-a24c-7872028a4f87.png">


To test this PR,
1. Checkout this PR and run `yarn:build`
2. Sideload the built extension located in `dist/chromium` into Google Chrome
3. Open the options page, and enter invalid content into the textbox 
4. Run `yarn test` to run all tests`