### PR TITLE
Display errors on error output (not console.log)

### DIFF
--- a/src/contentScript/buttonInjector/ButtonInjector.ts
+++ b/src/contentScript/buttonInjector/ButtonInjector.ts
@@ -4,5 +4,5 @@
  *-----------------------------------------------------------------------------------------------*/
 
 export interface ButtonInjector {
-    inject(): void
+    inject(): Promise<void>
 }

--- a/src/contentScript/buttonInjector/github/GitHubButtonInjector.tsx
+++ b/src/contentScript/buttonInjector/github/GitHubButtonInjector.tsx
@@ -89,9 +89,6 @@ export class GitHubButtonInjector implements ButtonInjector {
         }
 
         const projectURL = getProjectURL();
-        if (!projectURL) {
-            throw new Error("Could not detect project URL.");
-        }
 
         const endpoints = await getEndpoints();
         this.setActiveEndpointToFront(endpoints);

--- a/src/contentScript/buttonInjector/util.ts
+++ b/src/contentScript/buttonInjector/util.ts
@@ -5,9 +5,15 @@
 
 import { Endpoint } from "../../preferences/preferences";
 
-export function getProjectURL() {
+export function getProjectURL(): string {
     const meta = document.querySelector('meta[property="og:url"]');
-    return meta ? meta.getAttribute("content") : undefined;
+    const projectURL = meta.getAttribute("content");
+    if (!projectURL) {
+        throw new Error(
+            `Could not detect project URL for '${window.location.href}'.`
+        );
+    }
+    return projectURL;
 }
 
 export function getFactoryURL(projectURL: string, endpoint: Endpoint) {

--- a/src/contentScript/contentScript.tsx
+++ b/src/contentScript/contentScript.tsx
@@ -5,9 +5,4 @@
 
 import { ButtonInjectorFactory } from "./buttonInjector/ButtonInjectorFactory";
 
-try {
-    ButtonInjectorFactory.getButtonInjector()?.inject();
-} catch (e) {
-    const message = e instanceof Error ? e.message : e;
-    console.log(`try-in-web-ide-browser-extension error: ${message}`);
-}
+ButtonInjectorFactory.getButtonInjector()?.inject();


### PR DESCRIPTION
Instead of trying to catch and print errors to console, display errors in the errors tab in Google Chrome.

This can help make it easier to determine when the extension throws an error