### PR TITLE
Update readme for prod build instructions

### DIFF
--- a/.devfile.yaml
+++ b/.devfile.yaml
@@ -24,7 +24,7 @@ commands:
     exec:
       label: "Run the build for safari or firefox"
       component: tooling-container
-      commandLine: yarn build:firefox-safari
+      commandLine: yarn build:sf
   - id: 4-run-tests
     exec:
       label: "Run tests"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,27 +2,29 @@
 
 After building the extension, sideload the extension located under the `dist` folder.
 
+NOTE: To sideload the web extension, the web browser must be a recent version that supports Manifest V3 web extensions.
+
 ## Chromium-based browsers (Google Chrome, Microsoft Edge, Brave, etc.)
 1. Open the extensions page by visiting `chrome://extensions`, `edge://extensions`, `brave://extensions`, etc.
 2. Enable `Developer mode`.
 3. Click `Load unpacked` and provide the location to the `dist/chromium` folder.
 4. In the extension's `Permissions` tab, provide the permissions to access data for `https://github.com`.
 
-## Firefox version
+## Firefox
 1. Open the `about:debugging` page.
 2. Navigate to `This Firefox`.
-3. Click `Load Temporary Add-on` then select any file in the `dist/firefox-safari` folder.
+3. Click `Load Temporary Add-on` then select any file in the `dist/safari-firefox` folder.
 4. Open the `about:addons` page.
 5. Under the extensions `Permissions` tab, provide permissions for the extension to access data on `https://github.com`.
 
 ![Step 5](./images/firefox/step-5.png)
 
-## Safari version
+## Safari
 To sideload the extension on Safari, Xcode is required.
 
 1. Open the terminal and run the following to create and open an Xcode project for the web extension:
 ```
-xcrun safari-web-extension-converter /path/to/dist/firefox-safari
+xcrun safari-web-extension-converter /path/to/dist/safari-firefox
 ```
 2. In the Xcode project, set the build target to `Try in Dev Spaces (macOS)` and start the build by pressing ▶.
 

--- a/README.md
+++ b/README.md
@@ -35,16 +35,34 @@ $ yarn build
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 To build for Firefox or Safari:
 ```
-$ yarn build:firefox-safari
+$ yarn build:sf
 ```
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-Once complete, the built extension will be located in either `dist/chromium` or `dist/firefox-safari`.
+Once complete, the built extension will be located in either `dist/chromium` or `dist/safari-firefox`.
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-For development, run `yarn watch` or `yarn watch:firefox-safari` to watch the source files to recompile on changes.
+For development, run `yarn watch` or `yarn watch:sf` to watch the source files to recompile on changes.
 
 3. Sideload the extension located under the `dist` folder into your web browser.
 For instructions for different web browsers, refer to [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+## Running and sideloading the production build
+
+#### Chromium-based browsers (Google Chrome, Microsoft Edge, Brave, etc.)
+```
+yarn build:prod
+```
+The built location is located in `dist/chromium`.
+
+#### For Safari and Firefox
+```
+# the built extension is located in dist/safari-firefox
+yarn build:prod-sf
+```
+The built location is located in `dist/safari-firefox`.
+
+#### Sideloading the extension into the web browser
+Refer to [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## Running tests
 ```

--- a/package.json
+++ b/package.json
@@ -47,10 +47,11 @@
   },
   "scripts": {
     "build": "webpack --config webpack.dev.js",
-    "build:firefox-safari": "cross-env TARGET=firefox-safari webpack --config webpack.dev.js",
+    "build:sf": "cross-env TARGET=safari-firefox webpack --config webpack.dev.js",
     "build:prod": "webpack --config webpack.prod.js",
+    "build:prod-sf": "cross-env TARGET=safari-firefox webpack --config webpack.prod.js",
     "watch": "yarn build --watch",
-    "watch:firefox-safari": "yarn build:firefox-safari --watch",
+    "watch:sf": "yarn build:sf --watch",
     "test": "jest"
   },
   "dependencies": {

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -18,7 +18,7 @@ import {
 import { Divider } from "@patternfly/react-core/components/Divider";
 import { Split, SplitItem } from "@patternfly/react-core/layouts/Split";
 import { Form, FormGroup } from "@patternfly/react-core/components/Form";
-import { TextInput } from "@patternfly/react-core/components/Textinput";
+import { TextInput } from "@patternfly/react-core/components/TextInput";
 import { ExclamationCircleIcon } from "@patternfly/react-icons/dist/js/icons/exclamation-circle-icon";
 import {
     Endpoint,

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,9 +1,9 @@
 const path = require("path");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 
-const isFirefoxSafari = process.env.TARGET == "firefox-safari";
+const isFirefoxSafari = process.env.TARGET == "safari-firefox";
 
-const TARGET_FOLDER = ["dist", isFirefoxSafari ? "firefox-safari" : "chromium"];
+const TARGET_FOLDER = ["dist", isFirefoxSafari ? "safari-firefox" : "chromium"];
 
 module.exports = (env) => {
     const isProduction = env == "production";
@@ -60,6 +60,9 @@ module.exports = (env) => {
                     },
                 },
             ],
+        },
+        performance: {
+            hints: false,
         },
         resolve: {
             extensions: [".tsx", ".ts", ".jsx", ".js", "..."],


### PR DESCRIPTION
This PR:
* Updates readme for the prod build instructions
* Renames package.json `firefox-safari` commands to `sf` (ex: `build:firefox-safari` to `build:sf`)
* Add `yarn build:prod-sf` command to perform the production build for safari/firefox
* For webpack, set `performance.hints` to `false` to hide the warnings from now (related to https://github.com/redhat-developer/try-in-dev-spaces-browser-extension/issues/38)
  * I've briefly experimented with the [webpack splitChunks plugin](https://webpack.js.org/plugins/split-chunks-plugin/), however the default OOTB config does not work with the web extension, need to investigate more 
  
Tested with Mac OS, Fedora and Windows 10