### PR TITLE
Update with new GitHub button class names

### DIFF
--- a/src/contentScript/buttonInjector/github/Button.tsx
+++ b/src/contentScript/buttonInjector/github/Button.tsx
@@ -97,7 +97,7 @@ export const Button = (props: Props) => {
     return (
         <div className="gh-btn-group ml-2" id="try-in-web-ide-btn">
             <a
-                className="gh-btn btn-primary"
+                className="gh-btn gh-btn-padding Button--primary Button"
                 href={getFactoryURL(props.projectURL, defaultEndpoint)}
                 target="_blank"
                 title={"Open the project on " + defaultEndpoint.url}

--- a/src/contentScript/buttonInjector/github/GitHubButtonInjector.tsx
+++ b/src/contentScript/buttonInjector/github/GitHubButtonInjector.tsx
@@ -35,7 +35,7 @@ export class GitHubButtonInjector implements ButtonInjector {
     }
 
     private static codeBtnExists(element: Element): boolean {
-        const btnList = element.getElementsByClassName("btn-primary btn");
+        const btnList = element.getElementsByClassName("Button--primary Button");
         for (const btn of btnList) {
             if ((btn as HTMLElement).innerText.indexOf("Code") > -1) {
                 return true;

--- a/src/contentScript/buttonInjector/github/__tests__/GitHubButtonInjector.spec.ts
+++ b/src/contentScript/buttonInjector/github/__tests__/GitHubButtonInjector.spec.ts
@@ -34,7 +34,7 @@ describe("Test GitHubButtonInjector.matches()", () => {
                 const div = document.createElement("div");
                 div.className = "file-navigation";
                 const codeBtn = document.createElement("summary");
-                codeBtn.className = "btn-primary btn";
+                codeBtn.className = "Button--primary Button--medium Button";
                 codeBtn.innerText = "Code";
                 div.appendChild(codeBtn);
                 return div;
@@ -127,12 +127,14 @@ describe("Inject button on GitHub project repo page", () => {
                 const div = document.createElement("div");
                 div.className = "file-navigation";
                 const codeBtn = document.createElement("summary");
-                codeBtn.className = "btn-primary btn";
+                codeBtn.className = "Button--primary Button--medium Button";
                 codeBtn.innerText = "Code";
                 div.appendChild(codeBtn);
                 return div;
             }
         );
+
+        expect(GitHubButtonInjector.matches()).toBe(true);
 
         const mockRoot = {
             render: jest.fn(),

--- a/src/contentScript/buttonInjector/github/__tests__/__snapshots__/Button.spec.tsx.snap
+++ b/src/contentScript/buttonInjector/github/__tests__/__snapshots__/Button.spec.tsx.snap
@@ -7,7 +7,7 @@ exports[`Snapshot tests renders correctly with multiple endpoints 1`] = `
     id="try-in-web-ide-btn"
   >
     <a
-      class="gh-btn btn-primary"
+      class="gh-btn gh-btn-padding Button--primary Button"
       href="https://url-1.com/#https://github.com/redhat-developer/try-in-dev-spaces-browser-extension"
       target="_blank"
       title="Open the project on https://url-1.com"
@@ -30,7 +30,7 @@ exports[`Snapshot tests renders correctly with multiple endpoints, with dropdown
     id="try-in-web-ide-btn"
   >
     <a
-      class="gh-btn btn-primary"
+      class="gh-btn gh-btn-padding Button--primary Button"
       href="https://url-1.com/#https://github.com/redhat-developer/try-in-dev-spaces-browser-extension"
       target="_blank"
       title="Open the project on https://url-1.com"
@@ -114,7 +114,7 @@ exports[`Snapshot tests renders correctly with one endpoint 1`] = `
     id="try-in-web-ide-btn"
   >
     <a
-      class="gh-btn btn-primary"
+      class="gh-btn gh-btn-padding Button--primary Button"
       href="https://url-1.com/#https://github.com/redhat-developer/try-in-dev-spaces-browser-extension"
       target="_blank"
       title="Open the project on https://url-1.com"

--- a/src/contentScript/buttonInjector/github/styles/github.css
+++ b/src/contentScript/buttonInjector/github/styles/github.css
@@ -22,7 +22,6 @@
 .gh-btn {
     position: relative;
     display: inline-block;
-    padding: 5px 16px;
     font-size: 14px;
     font-weight: var(--base-text-weight-medium, 500);
     line-height: 20px;
@@ -35,6 +34,10 @@
     border-radius: 6px;
     -webkit-appearance: none;
     appearance: none;
+}
+
+.gh-btn-padding {
+    padding: 5px 16px !important;
 }
 
 .gh-btn:hover {


### PR DESCRIPTION
Currently the extension does not inject the button since there were some changes with the GitHub CSS class names

To test this PR:
1. Build and sideload the extension: https://github.com/redhat-developer/try-in-dev-spaces-browser-extension#building-and-running-locally
2. Confirm that the button is being injected:
<img width="837" alt="image" src="https://user-images.githubusercontent.com/83611742/228052139-29490678-ae11-4105-8d50-3e3f31546b89.png">
3. Confirm that all tests pass by running `yarn test`.
