### PR TITLE
Check for null return when getting project url

### DIFF
--- a/src/contentScript/buttonInjector/util.ts
+++ b/src/contentScript/buttonInjector/util.ts
@@ -7,7 +7,7 @@ import { Endpoint } from "../../preferences/preferences";
 
 export function getProjectURL(): string {
     const meta = document.querySelector('meta[property="og:url"]');
-    const projectURL = meta.getAttribute("content");
+    const projectURL = meta?.getAttribute("content");
     if (!projectURL) {
         throw new Error(
             `Could not detect project URL for '${window.location.href}'.`


### PR DESCRIPTION
Since `document.querySelector` can return `null` ([doc](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector#return_value)), this small PR checks for undefined/null before calling `getAttributes`

To test this PR:
1. Build and sideload the extension: https://github.com/redhat-developer/try-in-dev-spaces-browser-extension#building-and-running-locally
2. When creating a new workspace with the injected button on GitHub, the correct project should be cloned in the workspace