### PR TITLE
Add project to factory url using url parameter

### DIFF
--- a/src/contentScript/buttonInjector/github/__tests__/Button.spec.tsx
+++ b/src/contentScript/buttonInjector/github/__tests__/Button.spec.tsx
@@ -70,7 +70,7 @@ describe("Functional tests", () => {
 
         const btn = screen.getByText("Dev Spaces");
         expect((btn as HTMLAnchorElement).href).toEqual(
-            "https://url-1.com/#https://github.com/redhat-developer/try-in-dev-spaces-browser-extension"
+            "https://url-1.com/f?url=https://github.com/redhat-developer/try-in-dev-spaces-browser-extension"
         );
     });
 
@@ -87,7 +87,7 @@ describe("Functional tests", () => {
 
         const btn = screen.getByText("Dev Spaces");
         expect((btn as HTMLAnchorElement).href).toEqual(
-            "https://url-1.com/#https://github.com/redhat-developer/try-in-dev-spaces-browser-extension"
+            "https://url-1.com/f?url=https://github.com/redhat-developer/try-in-dev-spaces-browser-extension"
         );
     });
 
@@ -104,7 +104,7 @@ describe("Functional tests", () => {
 
         const btn = screen.getByText("Dev Spaces");
         expect((btn as HTMLAnchorElement).href).toEqual(
-            "https://url-2.com/#https://github.com/redhat-developer/try-in-dev-spaces-browser-extension"
+            "https://url-2.com/f?url=https://github.com/redhat-developer/try-in-dev-spaces-browser-extension"
         );
     });
 

--- a/src/contentScript/buttonInjector/github/__tests__/__snapshots__/Button.spec.tsx.snap
+++ b/src/contentScript/buttonInjector/github/__tests__/__snapshots__/Button.spec.tsx.snap
@@ -9,7 +9,7 @@ exports[`Snapshot tests renders correctly with multiple endpoints 1`] = `
     <a
       aria-label="Open the current project in a new tab on url-1.com"
       class="gh-btn gh-btn-padding Button--primary Button"
-      href="https://url-1.com/#https://github.com/redhat-developer/try-in-dev-spaces-browser-extension"
+      href="https://url-1.com/f?url=https://github.com/redhat-developer/try-in-dev-spaces-browser-extension"
       target="_blank"
       title="Open the current project in a new tab on url-1.com"
     >
@@ -34,7 +34,7 @@ exports[`Snapshot tests renders correctly with multiple endpoints, with dropdown
     <a
       aria-label="Open the current project in a new tab on url-1.com"
       class="gh-btn gh-btn-padding Button--primary Button"
-      href="https://url-1.com/#https://github.com/redhat-developer/try-in-dev-spaces-browser-extension"
+      href="https://url-1.com/f?url=https://github.com/redhat-developer/try-in-dev-spaces-browser-extension"
       target="_blank"
       title="Open the current project in a new tab on url-1.com"
     >
@@ -60,7 +60,7 @@ exports[`Snapshot tests renders correctly with multiple endpoints, with dropdown
         <a
           aria-label="Open the current project in a new tab on url-1.com"
           class="gh-dropdown-item"
-          href="https://url-1.com/#https://github.com/redhat-developer/try-in-dev-spaces-browser-extension"
+          href="https://url-1.com/f?url=https://github.com/redhat-developer/try-in-dev-spaces-browser-extension"
           target="_blank"
         >
           Open with url-1.com
@@ -78,7 +78,7 @@ exports[`Snapshot tests renders correctly with multiple endpoints, with dropdown
         <a
           aria-label="Open the current project in a new tab on url-2.com"
           class="gh-dropdown-item"
-          href="https://url-2.com/#https://github.com/redhat-developer/try-in-dev-spaces-browser-extension"
+          href="https://url-2.com/f?url=https://github.com/redhat-developer/try-in-dev-spaces-browser-extension"
           target="_blank"
         >
           Open with url-2.com
@@ -90,7 +90,7 @@ exports[`Snapshot tests renders correctly with multiple endpoints, with dropdown
         <a
           aria-label="Open the current project in a new tab on url-3.com"
           class="gh-dropdown-item"
-          href="https://url-3.com/#https://github.com/redhat-developer/try-in-dev-spaces-browser-extension"
+          href="https://url-3.com/f?url=https://github.com/redhat-developer/try-in-dev-spaces-browser-extension"
           target="_blank"
         >
           Open with url-3.com
@@ -125,7 +125,7 @@ exports[`Snapshot tests renders correctly with one endpoint 1`] = `
     <a
       aria-label="Open the current project in a new tab on url-1.com"
       class="gh-btn gh-btn-padding Button--primary Button"
-      href="https://url-1.com/#https://github.com/redhat-developer/try-in-dev-spaces-browser-extension"
+      href="https://url-1.com/f?url=https://github.com/redhat-developer/try-in-dev-spaces-browser-extension"
       target="_blank"
       title="Open the current project in a new tab on url-1.com"
     >

--- a/src/contentScript/buttonInjector/util.ts
+++ b/src/contentScript/buttonInjector/util.ts
@@ -17,7 +17,7 @@ export function getProjectURL(): string {
 }
 
 export function getFactoryURL(projectURL: string, endpoint: Endpoint) {
-    return endpoint.url + "/#" + projectURL;
+    return endpoint.url + "/f?url=" + projectURL;
 }
 
 export function getHostName(endpoint: Endpoint) {


### PR DESCRIPTION
This PR creates factory URLs in this format:
```
<che-host>/f?url=<git projectUrl>
```

instead of this format:
```
<che-host>/#<git project url>
```

To test this PR:
1. Build and sideload the extension: https://github.com/redhat-developer/try-in-dev-spaces-browser-extension#building-and-running-locally
2. Confirm that the 'Dev Spaces' button in GitHub can create workspaces