### PR TITLE
Add a 'Support' section

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -45,15 +45,28 @@
                         class="font-medium text-blue-600 dark:text-blue-500 hover:underline">Red Hat Developer
                         Sandbox</a>.
                 </p>
+            </div>
+
+            <div class="my-8">
+                <h1 class="text-2xl font-bold my-4" id="support">
+                    Support
+                </h1>
+                <p class="mb-4">
+                    The Try in Dev Spaces Browser Extension is open source on <a
+                        href="https://github.com/redhat-developer/try-in-dev-spaces-browser-extension"
+                        class="font-medium text-blue-600 dark:text-blue-500 hover:underline">GitHub</a> under the <a
+                        href="https://github.com/redhat-developer/try-in-dev-spaces-browser-extension/blob/main/LICENSE"
+                        class="font-medium text-blue-600 dark:text-blue-500 hover:underline">MIT license</a>.
+                </p>
+                <p class="mb-4">
+                    For questions, concerns, issues or feature requests, please <a
+                        href="https://github.com/redhat-developer/try-in-dev-spaces-browser-extension/issues/new"
+                        class="font-medium text-blue-600 dark:text-blue-500 hover:underline">file an issue</a> on the
+                    GitHub repository.
+                </p>
 
                 <p class="mb-4">
-                    The extension's source code is hosted on <a
-                        href="https://github.com/redhat-developer/try-in-dev-spaces-browser-extension"
-                        class="font-medium text-blue-600 dark:text-blue-500 hover:underline">GitHub</a> and is available
-                    under the MIT license. Pull requests are welcome. If you have any questions, concerns, issues or
-                    feature requests, please <a
-                        href="https://github.com/redhat-developer/try-in-dev-spaces-browser-extension/issues/new"
-                        class="font-medium text-blue-600 dark:text-blue-500 hover:underline">file an issue</a>.
+                    Alternatively, you can contact the developers at dakwon[at]redhat.com.
                 </p>
             </div>
 
@@ -76,7 +89,8 @@
                     <li>
                         Access to your data on github.com is required for:
                         <ul class="list-disc list-inside pl-4">
-                            <li>Determining the GitHub repository URL to construct hyperlinks required for the "Dev Spaces" button</li>
+                            <li>Determining the GitHub repository URL to construct hyperlinks required for the "Dev
+                                Spaces" button</li>
                             <li>Injecting the "Dev Spaces" button element into the GitHub repository web page</li>
                         </ul>
                     </li>
@@ -88,9 +102,8 @@
                     </li>
                 </ul>
                 <p class="my-4">
-                    If you believe this privacy policy has been violated, please <a
-                        href="https://github.com/redhat-developer/try-in-dev-spaces-browser-extension/issues/new"
-                        class="font-medium text-blue-600 dark:text-blue-500 hover:underline">file an issue</a>.
+                    If you believe this privacy policy has been violated, please refer to <a href="#support"
+                        class="font-medium text-blue-600 dark:text-blue-500 hover:underline">Support</a>.
                 </p>
             </div>
         </div>


### PR DESCRIPTION
Adds a "Support" section for the extension in the gh-pages webpage:
<img width="731" alt="image" src="https://github.com/redhat-developer/try-in-dev-spaces-browser-extension/assets/83611742/3114f493-f396-4bf6-a298-e3247d4fd4a3">
