### PR TITLE
Add devfile

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,0 +1,28 @@
+schemaVersion: 2.2.0
+metadata:
+  name: try-in-dev-spaces-webpage
+components:
+  - name: tools
+    container:
+      image: quay.io/devfile/universal-developer-image:ubi8-latest
+      mountSources: true
+      endpoints:
+        - name: live-server
+          targetPort: 8080
+          protocol: https
+          secure: true
+          exposure: public
+          path: /docs
+commands:
+  - id: download
+    exec:
+      label: "Download dependencies"
+      component: tools
+      workingDir: ${PROJECT_SOURCE}
+      commandLine: "yarn"
+  - id: development-server
+    exec:
+      label: "Run development server"
+      component: tools
+      workingDir: ${PROJECT_SOURCE}
+      commandLine: "yarn run start"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "start": "concurrently \"yarn run tailwind-css\" \"yarn run live-server\"",
-    "live-server": "live-server --port=8080 --open=docs",
+    "live-server": "live-server --port=8080 --open=docs --no-browser",
     "tailwind-css": "npx tailwindcss -i ./docs/input.css -o ./docs/dist/output.css --watch --minify"
   }
 }


### PR DESCRIPTION
Add devfile with commands.

1. To test this PR, create a workspace with this URL:
```
{CHE-HOST}/#https://github.com/dkwon17/try-in-web-ide-browser-extension/tree/gh-pages-devfile
```

2. Run the `Download dependencies` and `Run development server` tasks.

3. When the prompt appears, click `Open In New Tab`
<img width="469" alt="image" src="https://github.com/redhat-developer/try-in-dev-spaces-browser-extension/assets/83611742/1c7378b9-a9fb-4ab9-9f42-d0573bcf2790">

4. The GH pages webpage should open in a new tab
