### PR TITLE
Split Safari and Firefox builds

### DIFF
--- a/.devfile.yaml
+++ b/.devfile.yaml
@@ -20,12 +20,17 @@ commands:
       label: "Build for Chrome"
       component: tooling-container
       commandLine: yarn build
-  - id: 3-build-safari-firefox
+  - id: 3-build-safari
     exec:
-      label: "Build for Safari and Firefox"
+      label: "Build for Safari"
       component: tooling-container
-      commandLine: yarn build:sf
-  - id: 4-run-tests
+      commandLine: yarn build:safari
+  - id: 4-build-firefox
+    exec:
+      label: "Build for Firefox"
+      component: tooling-container
+      commandLine: yarn build:firefox
+  - id: 5-run-tests
     exec:
       label: "Run the tests"
       component: tooling-container

--- a/README.md
+++ b/README.md
@@ -39,15 +39,20 @@ To build for Chromium-based browsers:
 $ yarn build
 ```
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-To build for Firefox or Safari:
+To build for Safari:
 ```
-$ yarn build:sf
+$ yarn build:safari
 ```
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-Once complete, the built extension will be located in either `dist/chromium` or `dist/safari-firefox`.
+To build for Firefox:
+```
+$ yarn build:firefox
+```
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+Once complete, the built extension will be located in either `dist/chromium` or `dist/safari` or `dist/firefox`.
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-For development, run `yarn watch` or `yarn watch:sf` to watch the source files to recompile on changes.
+For development, run `yarn watch`, `yarn watch:safari`, or `yarn watch:firefox` to watch the source files to recompile on changes.
 
 3. Sideload the extension located under the `dist` folder into your web browser.
 For instructions for different web browsers, refer to [CONTRIBUTING.md](./CONTRIBUTING.md).
@@ -60,10 +65,17 @@ yarn build:prod
 ```
 The built location is located in `dist/chromium`.
 
-#### For Safari and Firefox
+#### For Safari
 ```
 # the built extension is located in dist/safari-firefox
-yarn build:prod-sf
+yarn build:prod-safari
+```
+The built location is located in `dist/safari-firefox`.
+
+#### For Firefox
+```
+# the built extension is located in dist/firefox
+yarn build:prod-firefox
 ```
 The built location is located in `dist/safari-firefox`.
 

--- a/package.json
+++ b/package.json
@@ -48,11 +48,14 @@
   },
   "scripts": {
     "build": "webpack --config webpack.dev.js",
-    "build:sf": "cross-env TARGET=safari-firefox webpack --config webpack.dev.js",
+    "build:safari": "cross-env TARGET=safari webpack --config webpack.dev.js",
+    "build:firefox": "cross-env TARGET=firefox webpack --config webpack.dev.js",
     "build:prod": "webpack --config webpack.prod.js",
-    "build:prod-sf": "cross-env TARGET=safari-firefox webpack --config webpack.prod.js",
+    "build:prod-safari": "cross-env TARGET=safari webpack --config webpack.prod.js",
+    "build:prod-firefox": "cross-env TARGET=firefox webpack --config webpack.prod.js",
     "watch": "yarn build --watch",
-    "watch:sf": "yarn build:sf --watch",
+    "watch:safari": "yarn build:safari --watch",
+    "watch:firefox": "yarn build:firefox --watch",
     "test": "jest"
   },
   "dependencies": {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,9 +1,10 @@
 const path = require("path");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 
-const isFirefoxSafari = process.env.TARGET == "safari-firefox";
+const SAFARI = "safari";
+const FIREFOX = "firefox";
 
-const TARGET_FOLDER = ["dist", isFirefoxSafari ? "safari-firefox" : "chromium"];
+const TARGET_FOLDER = ["dist", process.env.TARGET ? process.env.TARGET : "chromium"];
 
 module.exports = (env) => {
     const isProduction = env == "production";
@@ -75,13 +76,16 @@ function copyManifestToDist(isProduction) {
     function getModifiedManifest(content) {
         const manifest = JSON.parse(content.toString());
 
-        if (isFirefoxSafari) {
+        if (process.env.TARGET === SAFARI || process.env.TARGET === FIREFOX) {
             // for Firefox/Safari, background scripts are declared in the manifest differently
             const backgroundScript = manifest.background.service_worker;
             manifest.background = { scripts: [backgroundScript] };
 
+            if (process.env.TARGET === FIREFOX) {
             // optional_host_permissions should be merged into optional_permissions
             manifest.optional_permissions = manifest.optional_permissions.concat(manifest.optional_host_permissions);
+            delete manifest.optional_host_permissions;
+            }
         } else {
             // for Chromium based browsers browser_specific_settings is not supported
             delete manifest["browser_specific_settings"];


### PR DESCRIPTION
Currently, to build/watch the extension for Safari or Firefox, the commands to do so are:
```
yarn watch:sf
yarn build:sf
yarn build:prod-sf
``` 
which builds the extension and places it in the `dist/safari-firefox` folder.

In other words, the Safari and Firefox extension build is currently the same.

However, due to #73 , which adds the [optional_host_permissions](https://github.com/redhat-developer/try-in-dev-spaces-browser-extension/blob/8a52378a82aff8074338688d43cb0e1d233eabf9/manifest.json#L10) in the manifest, the issue is that Firefox does not currently support this field, and instead, is merged with `optional_permissions` instead (see the note in the Firefox Host Permissions [doc](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions#host_permissions)).

As a result, this PR splits the Safari and Firefox build commands (ex. `yarn build:sf`) to two different build commands (`yarn build:safari` and `yarn build:firefox`)

To test this extension:
1. checkout this extension and run:
```
yarn
```

2. Run:
```
yarn build (or yarn watch)
```
and verify that the `dist/chromium` folder is created

3. Run:
```
yarn build:safari (or yarn watch:safari)
```
and verify that the `dist/safari` folder is created

4. Run:
```
yarn build:firefox (or yarn build:firefox)
```
and verify that the `dist/firefox` folder is created



