### PR TITLE
Trim url of leading/trailing whitespaces when adding GH domains

### DIFF
--- a/src/contentScript/buttonInjector/github/__tests__/GitHubButtonInjector.spec.ts
+++ b/src/contentScript/buttonInjector/github/__tests__/GitHubButtonInjector.spec.ts
@@ -21,6 +21,7 @@ describe("Test GitHubButtonInjector.matches()", () => {
 
     afterEach(() => {
         jest.clearAllMocks();
+        preferencesMock.reset();
     });
 
     it("should return true if div has 'Code' button", async () => {
@@ -80,6 +81,7 @@ describe("Inject button on GitHub project repo page", () => {
 
     afterEach(() => {
         jest.clearAllMocks();
+        preferencesMock.reset();
     });
 
     it("should inject react element", async () => {

--- a/src/options/FormUI.tsx
+++ b/src/options/FormUI.tsx
@@ -61,7 +61,7 @@ export const FormUI = (props: Props) => {
 
     const addBtnClicked = async () => {
         try {
-            const success = await props.onAdd(newUrl);
+            const success = await props.onAdd(newUrl.trim());
             if (success) {
                 setNewUrl("");
                 setNewUrlStatus("default");

--- a/src/options/__tests__/DevSpacesEndpoints.spec.tsx
+++ b/src/options/__tests__/DevSpacesEndpoints.spec.tsx
@@ -12,6 +12,10 @@ const preferencesMock = require("../../preferences/preferences");
 
 jest.mock("../../preferences/preferences");
 
+afterEach(() => {
+    preferencesMock.reset();
+});
+
 it("renders correctly with one endpoint", async () => {
     preferencesMock.setEndpoints([
         { url: "https://url-1.com", active: true, readonly: true },

--- a/src/preferences/__mocks__/preferences.ts
+++ b/src/preferences/__mocks__/preferences.ts
@@ -22,4 +22,8 @@ module.exports = {
     setGitDomains(_gitDomains: string[]) {
         gitDomains = _gitDomains;
     },
+    reset() {
+        endpoints = [];
+        gitDomains = [];
+    },
 };


### PR DESCRIPTION
…oints or GH domains

Fixes the problem where GH domains cannot be added from the options menu when there are leading/trailing whitespaces:

https://github.com/redhat-developer/try-in-dev-spaces-browser-extension/assets/83611742/6968a4ae-f9a3-4b5f-b28f-fa0d578295ef

